### PR TITLE
Move Environment setup to common repo

### DIFF
--- a/modules/ROOT/partials/partial_environment_setup.adoc
+++ b/modules/ROOT/partials/partial_environment_setup.adoc
@@ -5,18 +5,24 @@ In order to interact with Starknet and compile Cairo code, you need to install s
 
 The following tools are recommended to begin developing on Starknet:
 
-[horizontal,labelwidth="25"]
-https://github.com/xJonathanLEI/starkli[Starkli]:: A command-line interface that allows you to interact with Starknet.
-+
-* Official documentation: link:https://book.starkli.rs/[book.starkli.rs]
-* Code Repository:
-link:https://github.com/xJonathanLEI/starkli[github.com/xJonathanLEI/starkli]
 
-https://github.com/software-mansion/scarb[Scarb]:: A package manager for Cairo. Among other features, it enables you to compile Cairo code to Sierra, the intermediate language between high-level Cairo and the low-level Cairo Assembly (CASM).
-+
-* Official documentation: link:https://docs.swmansion.com/scarb/[docs.swmansion.com/scarb]
-* Code Repository:
-link:https://github.com/software-mansion/scarb[github.com/software-mansion/scarb]
+
+[cols="1,1,1,1"]
+[%autowidth.stretch]
+|===
+|Tool name | Description | Documentation |Code Repository
+
+|Starkli
+|A command-line interface that allows you to interact with Starknet.
+|https://book.starkli.rs/[book.starkli.rs]
+|https://github.com/xJonathanLEI/starkli[github.com/xJonathanLEI/starkli]
+
+|Scarb
+|A build toolchain and package manager for Cairo and Starknet ecosystems.
+|https://docs.swmansion.com/scarb/[docs.swmansion.com/scarb]
+|https://github.com/software-mansion/scarb[github.com/software-mansion/scarb]
+
+|===
 
 [#installing_starkli]
 == Installing Starkli

--- a/modules/ROOT/partials/partial_environment_setup.adoc
+++ b/modules/ROOT/partials/partial_environment_setup.adoc
@@ -7,8 +7,16 @@ The following tools are recommended to begin developing on Starknet:
 
 [horizontal,labelwidth="25"]
 https://github.com/xJonathanLEI/starkli[Starkli]:: A command-line interface that allows you to interact with Starknet.
++
+* Official documentation: link:https://book.starkli.rs/[book.starkli.rs]
+* Code Repository:
+link:https://github.com/xJonathanLEI/starkli[github.com/xJonathanLEI/starkli]
 
 https://github.com/software-mansion/scarb[Scarb]:: A package manager for Cairo. Among other features, it enables you to compile Cairo code to Sierra, the intermediate language between high-level Cairo and the low-level Cairo Assembly (CASM).
++
+* Official documentation: link:https://docs.swmansion.com/scarb/[docs.swmansion.com/scarb]
+* Code Repository:
+link:https://github.com/software-mansion/scarb[github.com/software-mansion/scarb]
 
 [#installing_starkli]
 == Installing Starkli


### PR DESCRIPTION
This PR updates the content used in https://docs.starknet.io/documentation/quick_start/environment_setup/.