### PR TITLE
Docs: Add katana, Starknet devnet and Starknet Foundry installation

### DIFF
--- a/modules/ROOT/partials/partial_devtools.adoc
+++ b/modules/ROOT/partials/partial_devtools.adoc
@@ -115,7 +115,7 @@ With starknet-devnet-rs, you can do the following:
 link:https://github.com/0xSpaceShard/starknet-devnet-rs[The starknet-devnet-rs Github repository]
 
 
-[#Katana]
+[#katana]
 == Katana
 
 [discrete]

--- a/modules/ROOT/partials/partial_devtools.adoc
+++ b/modules/ROOT/partials/partial_devtools.adoc
@@ -138,7 +138,7 @@ With starknet-devnet and starknet-devnet-rs You can do the following:
 * link:https://github.com/0xSpaceShard/starknet-devnet-rs[The starknet-devnet-rs Github repository]
 
 
-[#katana]
+[#Katana]
 == Katana
 
 [discrete]

--- a/modules/ROOT/partials/partial_environment_setup.adoc
+++ b/modules/ROOT/partials/partial_environment_setup.adoc
@@ -135,7 +135,7 @@ The steps for installing Katana and upgrading Katana are identical.
 
 .Procedure
 
-. Install dojoup, the installer for the Katana toolchain:
+. Install Dojoup, the installer for the Katana toolchain:
 +
 [source,shell]
 ----
@@ -162,4 +162,4 @@ Katana should now be installed.
 katana --version
 ----
 +
-katana prints the current version.
+Katana prints the current version.

--- a/modules/ROOT/partials/partial_environment_setup.adoc
+++ b/modules/ROOT/partials/partial_environment_setup.adoc
@@ -25,10 +25,15 @@ The following tools are recommended to begin developing on Starknet:
 |https://book.dojoengine.org/toolchain/katana/overview[book.dojoengine.org]
 |https://github.com/dojoengine/dojo[github.com/dojoengine/dojo]
 
-|Starknet Foundry
+|Starknet-Foundry
 |A toolchain for developing Starknet smart contracts. It helps with writing, deploying, and testing your smart contracts.
 |https://foundry-rs.github.io/starknet-foundry/[foundry-rs.github.io/starknet-foundry]
 |https://github.com/foundry-rs/starknet-foundry/[github.com/foundry-rs/starknet-foundry]
+
+|Starknet-Devnet
+|A local testnet for Starknet in Rust.
+|https://0xspaceshard.github.io/starknet-devnet-rs/[0xspaceshard.github.io/starknet-devnet-rs]
+|https://github.com/0xSpaceShard/starknet-devnet-rs/[github.com/0xSpaceShard/starknet-devnet-rs]
 
 |===
 
@@ -204,3 +209,39 @@ snforge --version
 ----
 +
 Starknet Foundry prints the current version.
+
+[#installing_starknet_devnet]
+== Installing Starknet Devnet
+
+The steps for installing Starknet Devnet and upgrading Starknet Devnet are identical.
+
+.Procedure
+
+. Install Rust using rustup 
++
+[source,shell]
+----
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+----
++
+Rust should now be installed.
+
+. Restart the terminal.
+
+. Install Starknet Devnet:
++
+[source,shell]
+----
+cargo install starknet-devnet
+----
++
+Starknet Devnet should now be installed.
+
+. Restart the terminal and run the following command to verify the installation:
++
+[source,shell]
+----
+starknet-devnet --version
+----
++
+Starknet Devnet prints the current version.

--- a/modules/ROOT/partials/partial_environment_setup.adoc
+++ b/modules/ROOT/partials/partial_environment_setup.adoc
@@ -20,6 +20,11 @@ The following tools are recommended to begin developing on Starknet:
 |https://docs.swmansion.com/scarb/[docs.swmansion.com/scarb]
 |https://github.com/software-mansion/scarb[github.com/software-mansion/scarb]
 
+|Katana
+|An extremely fast devnet designed to support local development. 
+|https://book.dojoengine.org/toolchain/katana/overview[book.dojoengine.org]
+|https://github.com/dojoengine/dojo[github.com/dojoengine/dojo]
+
 |===
 
 [#installing_starkli]
@@ -122,3 +127,39 @@ scarb --version
 ----
 
 Scarb should now be installed.
+
+[#installing_katana]
+== Installing Katana
+
+The steps for installing Katana and upgrading Katana are identical.
+
+.Procedure
+
+. Install dojoup, the installer for the Katana toolchain:
++
+[source,shell]
+----
+curl -L https://install.dojoengine.org | bash
+----
++
+Dojoup should now be installed.
+
+. Restart the terminal.
+
+. Install Katana:
++
+[source,shell]
+----
+dojoup
+----
++
+Katana should now be installed.
+
+. Restart the terminal and run the following command to verify the installation:
++
+[source,shell]
+----
+katana --version
+----
++
+katana prints the current version.

--- a/modules/ROOT/partials/partial_environment_setup.adoc
+++ b/modules/ROOT/partials/partial_environment_setup.adoc
@@ -25,6 +25,11 @@ The following tools are recommended to begin developing on Starknet:
 |https://book.dojoengine.org/toolchain/katana/overview[book.dojoengine.org]
 |https://github.com/dojoengine/dojo[github.com/dojoengine/dojo]
 
+|Starknet Foundry
+|A toolchain for developing Starknet smart contracts. It helps with writing, deploying, and testing your smart contracts.
+|https://foundry-rs.github.io/starknet-foundry/[foundry-rs.github.io/starknet-foundry]
+|https://github.com/foundry-rs/starknet-foundry/[github.com/foundry-rs/starknet-foundry]
+
 |===
 
 [#installing_starkli]
@@ -163,3 +168,39 @@ katana --version
 ----
 +
 Katana prints the current version.
+
+[#installing_starknet_foundry]
+== Installing Starknet Foundry
+
+The steps for installing Starknet Foundry and upgrading Starknet Foundry are identical.
+
+.Procedure
+
+. Install Snfoundryup, the installer for the Starknet Foundry toolkit:
++
+[source,shell]
+----
+curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
+----
++
+Snfoundryup should now be installed.
+
+. Restart the terminal.
+
+. Install Starknet Foundry:
++
+[source,shell]
+----
+snfoundryup
+----
++
+Starknet Foundry should now be installed.
+
+. Restart the terminal and run the following command to verify the installation:
++
+[source,shell]
+----
+snforge --version
+----
++
+Starknet Foundry prints the current version.


### PR DESCRIPTION
Hi team

Since I am working on a [katana tutorial and starknet fundry tutorial](https://github.com/starknet-io/starknet-docs/pull/1191) for starknet-docs.
I suggest to add the katana, Starknet devnet and Starknet Foundry installation on this section

Please check @stoobie 