### PR TITLE
docs: Remove Python-based starknet-devnet

### DIFF
--- a/modules/ROOT/partials/partial_devtools.adoc
+++ b/modules/ROOT/partials/partial_devtools.adoc
@@ -16,26 +16,6 @@ The tools listed here do not represent all that are available.
 .Tools for each stage of development
 image::1.0.0@docs-common-content:ROOT:image$tools_workflow.jpg[]
 
-// .Tools for each stage of development
-// |===
-// | *Coding in Cairo* | xref:#vs_code_cairo_extension[_VsCode_ + _Cairo plugin_] +
-// or +
-// xref:#starknet_remix_plugin[_Remix_ + _Cairo plugin_]
-// | *Building* | xref:#scarb[_Scarb_]
-// | *Testing and debugging* | xref:#starknet_foundry[_Foundry (Forge)_] +
-// or +
-// xref:#hardhat[_Hardhat_ + _Starknet plugin (JavaScript only)_]
-// | *Running on a devnet* |_Scarb_ for compiling and packaging +
-// xref:#starknet-devnet[_starknet-devnet_/_starknet-devnet-rs_ (local node)] +
-// or +
-// xref:#katana[_Katana_ (local node)]
-// | *Contract development* | xref:#starknet_foundry[_Foundry (Cast)_]
-// or
-// xref:#starkli[_Starkli_]
-// | *Package delivery* +
-// (Optional) | _Scarb_
-// |===
-
 [#starkli]
 == Starkli
 
@@ -101,17 +81,15 @@ JavaScript, TypeScript
 |Starknet-go |Go |Chainlink |Nethermind | link:https://github.com/NethermindEth/starknet.go[starknet-go Github repository]
 |===
 
-[#starknet-devnet]
-== starknet-devnet, starknet-devnet-rs
+[#starknet-devnet-rs]
+== starknet-devnet-rs
 
 [discrete]
 === What is it?
 
-A devnet is a Starknet instance that you run as a local node, which enables much quicker development than is possible using testnet, as well as providing privacy prior to launching on testnet.
+A devnet is a Starknet instance that you run as a local node. A devnet enables much quicker development than is possible using testnet, as well as providing privacy prior to launching on testnet.
 
-SpaceShard originally wrote starknet-devnet in Python, but they are now actively developing a version in Rust, starknet-devnet-rs. For now, the Python-based version is more feature-rich, with the most notable feature being the ability to fork the network at a given block, so if that’s important to you, then you need to use the Python-based version. However, starknet-devnet-rs runs more quickly, and the developers are working to bring it to feature parity with the Python-based starknet-devnet.
-
-starknet-devnet-rs is the only version that is receiving new features.
+starknet-devnet-rs can, among other features, fork the network at a given block. starknet-devnet-rs runs more quickly than the previous, Python-based starknet-devnet.
 
 [discrete]
 === Who maintains it?
@@ -121,9 +99,9 @@ SpaceShard
 [discrete]
 === Why should you care?
 
-starknet-devnet and starknet-devnet-rs include some accounts that are already funded with an ERC-20 token that can be used to pay fees. The ERC-20 contract that defines this token is also included.
+starknet-devnet-rs includes some accounts that are already funded with an ERC-20 token that can be used to pay fees. The ERC-20 contract that defines this token is also included.
 
-With starknet-devnet and starknet-devnet-rs You can do the following:
+With starknet-devnet-rs, you can do the following:
 
 * Create mock accounts.
 * Send transactions using pre-deployed, pre-funded accounts, which are included.
@@ -134,8 +112,7 @@ With starknet-devnet and starknet-devnet-rs You can do the following:
 [discrete]
 === Where do you get it?
 
-* link:https://github.com/Shard-Labs/starknet-devnet[The starknet-devnet Gitbhub repository]
-* link:https://github.com/0xSpaceShard/starknet-devnet-rs[The starknet-devnet-rs Github repository]
+link:https://github.com/0xSpaceShard/starknet-devnet-rs[The starknet-devnet-rs Github repository]
 
 
 [#katana]


### PR DESCRIPTION
starknet-devnet is no longer in development. starknet-devnet-rs has replaced it.