### PR TITLE
feat(setting-up-environment): make more approachable

### DIFF
--- a/modules/ROOT/partials/partial_environment_setup.adoc
+++ b/modules/ROOT/partials/partial_environment_setup.adoc
@@ -1,35 +1,20 @@
 [id="setup"]
 = Setting up your environment
 
-In order to interact with Starknet and compile Cairo code, you need to install several tools.
-
-The following tools are recommended to begin developing on Starknet:
-
-[cols="1,1,1,1"]
-[%autowidth.stretch]
-|===
-|Tool name | Description | Documentation |Code Repository
-
-|Starkli
-|A command-line interface that allows you to interact with Starknet.
-|https://book.starkli.rs/[book.starkli.rs]
-|https://github.com/xJonathanLEI/starkli[github.com/xJonathanLEI/starkli]
-
-|Scarb
-|A build toolchain and package manager for Cairo and Starknet ecosystems.
-|https://docs.swmansion.com/scarb/[docs.swmansion.com/scarb]
-|https://github.com/software-mansion/scarb[github.com/software-mansion/scarb]
+In order to interact with Starknet and compile Cairo code, you just need a couple tools.
 
 |===
 
 [#installing_starkli]
-== Installing Starkli
+== Starkli
+
+A command-line interface that allows you to interact with Starknet.
 
 The steps for installing Starkli and upgrading Starkli are identical.
 
-.Procedure
+.Installation
 
-. Install Starkliup, the installer for the Starkli environment:
+. First you will need to install Starkliup, the installer for the Starkli environment:
 +
 [source,shell]
 ----
@@ -59,7 +44,7 @@ starkli --version
 Starkli prints the current version.
 
 [#setting_environment_variables_for_starkli]
-== Setting environment variables for Starkli
+=== Setting environment variables for Starkli
 
 For the majority of flags available on Starkli you can set environment variables to make the commands shorter and easier to manage.
 
@@ -80,7 +65,9 @@ export STARKNET_KEYSTORE=~/.starkli-wallets/deployer/keystore.json
 ----
 
 [#installing_scarb]
-== Installing Scarb
+== Scarb
+
+Scarb is build toolchain and package manager for Cairo (the language used by Starknet smart contracts) and the Starknet ecosystem.
 
 Scarb is compatible with macOS, Linux, and Windows operating systems.
 


### PR DESCRIPTION
When I first saw this page,

- it looked like a _huge_ table that extended off my screen
- it said I would need "several" tools, which exacerbated this affect
- it looked like there was no explanation of how to install them on this page, and that I would need to click through to each and follow its instructions
- when I clicked to "edit on GitHub", it brought me to a [an incomprehensible GitHub page](https://github.com/starknet-io/starknet-docs/edit/main/components/Starknet/modules/quick-start/pages/environment-setup.adoc). It took some guesswork and determination to figure out how to contribute to this doc!

This fixes the first three items, but I'm not sure how to address the
last one. Maybe just a comment, for now? Even when you clone the repo,
if you're not used to adoc, then the cross-repo `include` is hard to
figure out.

I've also updated a couple other readability & formatting issues I came across.

### TO DO:

- [ ] finish following along with doc before marking as Ready for Review
- [ ] await outcome of conversation in https://github.com/starknet-io/starknet-docs/pull/1398#issuecomment-2576067737